### PR TITLE
Add GitHub Actions workflow for Docker image build and publish

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,0 +1,98 @@
+name: CI/CD Pipeline
+
+on:
+  push:
+    branches: [ main ]
+    tags: [ 'v*' ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-test:
+    name: Build and Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Run tests
+        run: npm test
+        env:
+          JIRA_API_TOKEN: ${{ secrets.TEST_JIRA_API_TOKEN }}
+          JIRA_EMAIL: ${{ secrets.TEST_JIRA_EMAIL }}
+          JIRA_HOST: ${{ secrets.TEST_JIRA_HOST }}
+
+      - name: Build
+        run: npm run build
+
+  build-container:
+    name: Build and Push Container
+    needs: build-and-test
+    runs-on: ubuntu-latest
+    # Only run on main branch or tags
+    if: github.event_name != 'pull_request'
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=sha,format=long
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64
+          build-args: |
+            DOCKER_HASH=${{ github.sha }}
+
+      - name: Cleanup old packages
+        uses: actions/delete-package-versions@v4
+        with:
+          package-name: 'jira-insights-mcp'
+          package-type: container
+          min-versions-to-keep: 10
+          delete-only-untagged-versions: true


### PR DESCRIPTION
This PR adds a GitHub Actions workflow for building and publishing Docker images to GitHub Container Registry, following the pattern from the jira-cloud project. The workflow runs on pushes to the main branch, tags with 'v*' prefix, and pull requests to main. It includes two main jobs: build-and-test and build-container.